### PR TITLE
client_id and client_secret need to be in the POST body for oauth/token

### DIFF
--- a/services/public_api.py
+++ b/services/public_api.py
@@ -49,11 +49,16 @@ class RefreshTokenRequest:
     grant_type: str = "refresh_token"
 
     def execute(self, token_url, client_id, client_secret):
+        body = {
+            "grant_type": self.grant_type,
+            "refresh_token": self.refresh_token,
+            "client_id": client_id,
+            "client_secret": client_secret,
+        }
         response: requests.Response = requests.post(
             token_url,
-            data=asdict(self),
+            data=body,
             headers={"Accept": "application/json"},
-            auth=HTTPBasicAuth(client_id, client_secret),
             timeout=120,
         )
         return None if not response.ok else GetTokenResponse(

--- a/services/public_api.py
+++ b/services/public_api.py
@@ -24,11 +24,17 @@ class GetTokenRequest:
     grant_type: str = "authorization_code"
 
     def execute(self, token_url: str, client_id: str, client_secret: str) -> GetTokenResponse:
+        body = {
+            "grant_type": self.grant_type,
+            "code": self.code,
+            "redirect_uri": self.redirect_uri,
+            "client_id": client_id,
+            "client_secret": client_secret,
+        }
         response: requests.Response = requests.post(
             token_url,
-            data=asdict(self),
+            data=body,
             headers={"Accept": "application/json"},
-            auth=HTTPBasicAuth(client_id, client_secret),
             timeout=120,
         )
         return None if not response.ok else GetTokenResponse(


### PR DESCRIPTION
Recent changes elsewhere will return a 400 if `client_id` is not found within the request body.  Having both `client_id` and `client_secret` in the body is consistent with our docs: https://github.com/TrainingPeaks/PartnersAPI/wiki/OAuth